### PR TITLE
Update pair.py

### DIFF
--- a/defaults/py_modules/connector/packet/handler/pair.py
+++ b/defaults/py_modules/connector/packet/handler/pair.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class KDEPacketPairBody:
     pair: bool
+    timestamp: int = time.time()
 
 
 @dataclass
@@ -33,7 +34,8 @@ class KDEPacketPair(KDEPacketBase):
     def create(cls, pair: bool):
         return cls(
             body=KDEPacketPairBody(
-                pair=pair
+                pair=pair,
+                timestamp=time.time()
             )
         )
 


### PR DESCRIPTION
It seems like KDE connect started expecting timestamp elements in the body of the pairing packets.

Added a quick fix to resolve pairing process failing. Should fix Issue #4 